### PR TITLE
Add GetSingleItemData to get raw data with individual selectors

### DIFF
--- a/ebay_api.php
+++ b/ebay_api.php
@@ -78,7 +78,7 @@
                      $selector="&IncludeSelector=Details,Description,TextDescription,ItemSpecifics,Variations,Compatibility"){
             // add &selector= if not given
             if (strlen($selector) >1 && $selector[0] != '&') {
-                $selector="&selector=".$selector;
+                $selector="&IncludeSelector=".$selector;
             } 
             if($html_description === true){
                 // You can't grab both at the same time. So you have to ask for either or. Default is without the HTML Mark-up.

--- a/ebay_api.php
+++ b/ebay_api.php
@@ -8,12 +8,18 @@
             $this->ebay_app_id = "Your Ebay Application ID.";
             $this->ebay_dev_id = "Your Ebay development ID.";
             $this->ebay_client_secret = "Your Ebay Client Secret.";
+            $this->ebay_api_version = "1157";
+            $this->ebay_api_url = "https://open.api.ebay.com";
+            // uncomment to use sandbox credentials
+            //$this->ebay_api_url = "https://open.api.sandbox.ebay.com";
         }
         
         // Misc IDs
         private $ebay_app_id;
         private $ebay_dev_id;
         private $ebay_client_secret;
+        private $ebay_api_url;
+        private $ebay_api_version;
 
         // Main Vars
         private $call_logs = [];
@@ -42,11 +48,11 @@
             // Returns Greenwich Mean Time 
             // YYYY - MM - DD / HH:MM:SS:MS
         
-            $request_url = "https://open.api.ebay.com/shopping?callname=GeteBayTime"
+            $request_url = "{$this->ebay_api_url}/shopping?callname=GeteBayTime"
             . "&responseencoding=XML"
             . "&appid={$this->ebay_app_id}"
             . "&siteid=0"
-            . "&version=1157";
+            . "&version={$this->ebay_api_version}";
 
             $request = file_get_contents($request_url);
             $data = simplexml_load_string($request);
@@ -71,21 +77,21 @@
         function GetSingleItem($item_id, $site_id, $html_description){
             if($html_description === true){
                 // You can't grab both at the same time. So you have to ask for either or. Default is without the HTML Mark-up.
-                $request_url = "https://open.api.ebay.com/shopping?" 
+                $request_url = "{$this->ebay_api_url}/shopping?" 
                 . "callname=GetSingleItem"
                 . "&responseencoding=XML"
                 . "&appid={$this->ebay_app_id}"
                 . "&siteid={$site_id}"
-                . "&version=1157"
+                . "&version={$this->ebay_api_version}"
                 . "&ItemID={$item_id}"
                 . "&IncludeSelector=Details,Description,ItemSpecifics,Variations,Compatibility";
             } else {
-                $request_url = "https://open.api.ebay.com/shopping?" 
+                $request_url = "{$this->ebay_api_url}/shopping?" 
                 . "callname=GetSingleItem"
                 . "&responseencoding=XML"
                 . "&appid={$this->ebay_app_id}"
                 . "&siteid={$site_id}"
-                . "&version=1157"
+                . "&version={$this->ebay_api_version}"
                 . "&ItemID={$item_id}"
                 . "&IncludeSelector=Details,Description,TextDescription,ItemSpecifics,Variations,Compatibility";
             }

--- a/ebay_api.php
+++ b/ebay_api.php
@@ -93,7 +93,6 @@
                 . "&ItemID={$item_id}"
                 . $selector;
             $request = file_get_contents($request_url);
-print($request.PHP_EOL);
             $data = simplexml_load_string($request);
             return $data;
         }

--- a/ebay_api.php
+++ b/ebay_api.php
@@ -75,14 +75,16 @@
         }
 
         function GetSingleItemData($item_id, $site_id, $html_description,
-                     $selector="&IncludeSelector=Details,Description,TextDescription,ItemSpecifics,Variations,Compatibility"){
+                     $selector="&IncludeSelector=Details,Description,ItemSpecifics,Variations,Compatibility"){
             // add &selector= if not given
             if (strlen($selector) >1 && $selector[0] != '&') {
                 $selector="&IncludeSelector=".$selector;
             } 
-            if($html_description === true){
-                // You can't grab both at the same time. So you have to ask for either or. Default is without the HTML Mark-up.
-                $request_url = "{$this->ebay_api_url}/shopping?" 
+            if(strlen($selector) >1 && $html_description !== true){
+		// get descritption as text
+		$selector.=",TextDescription";
+	    }
+            $request_url = "{$this->ebay_api_url}/shopping?" 
                 . "callname=GetSingleItem"
                 . "&responseencoding=XML"
                 . "&appid={$this->ebay_app_id}"
@@ -90,16 +92,7 @@
                 . "&version={$this->ebay_api_version}"
                 . "&ItemID={$item_id}"
                 . $selector;
-            } else {
-                $request_url = "{$this->ebay_api_url}/shopping?" 
-                . "callname=GetSingleItem"
-                . "&responseencoding=XML"
-                . "&appid={$this->ebay_app_id}"
-                . "&siteid={$site_id}"
-                . "&version={$this->ebay_api_version}"
-                . "&ItemID={$item_id}"
-                . $selector;
-            }
+print($request_url.PHP_EOL);
             $request = file_get_contents($request_url);
             $data = simplexml_load_string($request);
             return $data;

--- a/ebay_api.php
+++ b/ebay_api.php
@@ -93,6 +93,7 @@
                 . "&ItemID={$item_id}"
                 . $selector;
             $request = file_get_contents($request_url);
+print($request.PHP_EOL);
             $data = simplexml_load_string($request);
             return $data;
         }
@@ -182,203 +183,80 @@
         }
         
         // These are utility functions built to help with general use of the API.    
-        function site2domain($site){
-            switch($site){
-                case "Australia":
-                    return "https://www.ebay.com.au/";
+        function id2site($site){
+            static $siteID = array(
+                "15"=>"Australia", "16"=>"Austria", "123"=>"Belgium_Dutch", "23"=>"Belgium_French", "2"=>"Canada", "210"=>"CanadaFrench",
+                "71"=>"France", "77"=>"Germany", "201"=>"HongKong", "203"=>"India", "205"=>"Ireland", "101"=>"Italy", "207"=>"Malaysia",
+                "146"=>"Netherlands", "211"=>"Philippines", "212"=>"Poland", "216"=>"Singapore", "186"=>"Spain", "193"=>"Switzerland",
+                "3"=>"UK", "0"=>"US"
+                );
+            if (array_key_exists($site, $siteID)) {
+                return $siteID[$site];
+            }       
+            return "US";
+        }
 
-                case "Austria":
-                    return "https://www.ebay.at/";
+        function site2id($site){
+            static $siteID = array(
+                "Australia"=>"15", "Austria"=>"16", "Belgium_Dutch"=>"123", "Belgium_French"=>"23", "Canada"=>"2", "CanadaFrench"=>"210",
+                "France"=>"71", "Germany"=>"77", "HongKong"=>"201", "India"=>"203", "Ireland"=>"205", "Italy"=>"101", "Malaysia"=>"207",
+                "Netherlands"=>"146", "Philippines"=>"211", "Poland"=>"212", "Singapore"=>"216", "Spain"=>"186", "Switzerland"=>"193",
+                "UK"=>"3", "US"=>"0"
+                );
+            if (array_key_exists($site, $siteID)) {
+                return $siteID[$site];
+            }       
+            return "0";
+        }
 
-                case "Belgium_Dutch":
-                    return "https://www.benl.ebay.be/";
-
-                case "Belgium_French":
-                    return "https://www.befr.ebay.be/";
-
-                case "Canada":
-                    return "https://www.ebay.ca/";
-
-                case "CanadaFrench":
-                    return "https://www.cafr.ebay.ca/";
-
-                case "France":
-                    return "https://www.ebay.fr/";
-                
-                case "Germany":
-                    return "https://www.ebay.de/";
-
-                case "HongKong":
-                    return "https://www.ebay.com.hk/";
-                
-                case "India":
-                    return "https://www.ebay.in/";
-
-                case "Ireland":
-                    return "https://www.ebay.ie/";
-
-                case "Italy":
-                    return "https://www.ebay.it/";
-                    
-                case "Malaysia":
-                    return "https://www.ebay.com.my/";
-
-                case "Netherlands":
-                    return "https://www.ebay.nl/";
-                    
-                case "Philippines":
-                    return "https://www.ebay.ph/";
-
-                case "Poland":
-                    return "https://www.ebay.pl/";
-
-                case "Singapore":
-                    return "https://www.ebay.sg/";
-
-                case "Spain":
-                    return "https://www.ebay.es/";
-
-                case "Switzerland":
-                    return "https://www.ebay.ch/";
-
-                case "UK":
-                    return "https://www.ebay.co.uk/";
-
-                case "US":
-                    return "https://www.ebay.com/";   
-                      
-            default:
-                return "https://www.ebay.com/";
-            }
+        function site2domain($site, $cc_only=false){
+            static $siteDomain = array(
+                "Australia"=>"au", "Austria"=>"at", "Belgium_Dutch"=>"be", "Belgium_French"=>"be", "Canada"=>"ca", "CanadaFrench"=>"ca",
+                "France"=>"fr", "Germany"=>"de", "HongKong"=>"hk", "India"=>"in", "Ireland"=>"ie", "Italy"=>"it", "Malaysia"=>"my",
+                "Netherlands"=>"nl", "Philippines"=>"ph", "Poland"=>"pl", "Singapore"=>"sg", "Spain"=>"es", "Switzerland"=>"ch",
+                "UK"=>"co.uk", "US"=>"com"
+                );
+            if (array_key_exists($site, $siteDomain)) {
+	        if ($cc_only) { return $siteDomain[$site]; }
+                return "https://www.ebay.{$siteDomain[$site]}/";
+            }       
+	    if ($cc_only) { return "com"; }
+            return "https://www.ebay.com/";
         }
         
         function site2global($site){
             // Site -> Global-ID
-            // Not all these are supported and ebay doesn't tell you what is. Need to manually check every single one to see if it works and if it doesn't remove it from the list.
-            // Currently Not Supported (Russia)
-            switch($site){
-                case "Australia":
-                    return "EBAY-AU";
-                
-                case "Austria":
-                    return  "EBAY-AT";
-            
-                case "Belgium_Dutch":
-                    return "EBAY-NLBE";
-
-                case "Belgium_French":
-                    return "EBAY-FRBE";
-
-                case "Canada":
-                    return "EBAY-ENCA";
-
-                case "CanadaFrench":
-                    return "EBAY-FRCA";
-            
-                case "France":
-                    return "EBAY-FR";
-
-                case "Germany":
-                    return "EBAY-DE";
-
-                case "HongKong":
-                    return "EBAY-HK";
-
-                case "India": 
-                    return "EBAY-IN";
-                
-                case "Ireland":
-                    return "EBAY-IE";
-
-                case "Italy":
-                    return "EBAY-IT";
-
-                case "Malaysia":
-                    return "EBAY-MY";
-
-                case "Netherlands":
-                    return "EBAY-NL";
-                
-                 case "Philippines":
-                    return "EBAY-PH";
-
-                case "Poland":
-                    return "EBAY-PL";
-
-                case "Spain":
-                    return "EBAY-ES";
-                                                       
-                case "Singapore":
-                    return "EBAY-SG";
-
-                case "Switzerland":
-                    return "EBAY-CH";
-
-                case "UK":
-                    return "EBAY-GB";
-
-                case "US":
-                    return "EBAY-US";
-                
-                case "Motors":
-                    return "EBAY-MOTOR";
-                    
-                default:
-                    return "EBAY-US";
-            }
+            // Not all these are supported and ebay doesn't tell you what is. Need to manually check every single one
+            // to see if it works and if it doesn't remove it from the list.
+            // Currently Not Supported: Russia
+            static $siteGlobal = array(
+                "Australia"=>"EBAY-AU", "Austria"=>"EBAY-AT", "Belgium_Dutch"=>"EBAY-NLBE", "Belgium_French"=>"EBAY-FRBE", "Canada"=>"EBAY-ENCA",
+                "CanadaFrench"=>"EBAY-FRCA", "France"=>"EBAY-FR", "Germany"=>"EBAY-DE", "HongKong"=>"EBAY-HK", "India"=>"EBAY-IN",
+                "Ireland"=>"EBAY-IE", "Italy"=>"EBAY-IT", "Malaysia"=>"EBAY-MY", "Netherlands"=>"EBAY-NL", "Philippines"=>"EBAY-PH",
+                "Poland"=>"EBAY-PL", "Spain"=>"EBAY-ES", "Singapore"=>"EBAY-SG", "Switzerland"=>"EBAY-CH", "UK"=>"EBAY-GB", "US"=>"EBAY-US",
+                "Motors"=>"EBAY-MOTOR"
+                );
+            if (array_key_exists($site, $siteGlobal)) {
+                return $siteGlobal[$site];
+            }       
+            return "EBAY-US";
         }
+
 
         function curr2sym($curr) {
             // Converts currency abbreviations to symbols. 
             // Only made this because I like having the symbol over chars.
             // USD = $, EUR = €, GBP = £, etc
             // This supports every domain on https://developer.ebay.com/DevZone/merchandising/docs/Concepts/SiteIDToGlobalID.html
-        
-            switch($curr){
-                case "USD":
-                    return "$";
-                    
-                case "GBP":
-                    return "£";
-                    
-                case "EUR":
-                    return "€";
-                    
-                case "CAD":
-                    // Canadian Money Symbols: $, C$, CAD, Can$
-                    return "C$";
-
-                case "AUD":
-                    // Australian Money Symbols: $, A$, AUD
-                    return "A$";
-
-                case "CHF": 
-                    // Switzerland Money Symbols: CHf, Fr., SFr.
-                    return "Fr.";
-
-                case "HKD":
-                    // Hong Kong Money Symbols: $, HK$
-                    return "HK$";
-                    
-                case "MYR":
-                    return "RM";
-
-                case "PHP":
-                    // hehe php (Phillipines)
-                    return "₱";
-
-                case "PLN":
-                    return "zł";
-                    
-                case "SGD":
-                    // Singapore Money Symbols: $, S$
-                    return "S$";
-                    
-                default:
-                    // If this fails somehow it'll just return the three chars instead of nothing.
-                    return $curr;
-            }
-            
+	    static $currSym = array (
+                "USD"=>"$", "GBP"=>"£", "EUR"=>"€", "CAD"=>"C$", "AUD"=>"A$", "CHF"=>"Fr.",
+                "HKD"=>"HK$", "MYR"=>"RM", "PHP"=>"₱", "PLN"=>"zł", "SGD"=>"S$"
+                 );
+            if (array_key_exists($curr, $currSym)) {
+                return $currSym[$curr];
+            }       
+            // If this fails somehow it'll just return the three chars instead of nothing.
+            return $curr;
         }
 
         function GrabItemID($ebay_url){

--- a/ebay_api.php
+++ b/ebay_api.php
@@ -389,16 +389,22 @@ print($request_url.PHP_EOL);
                 // The reason I decided to use Regex for this as it was the only consistent thing across all ebay domains.
                 // Also the reason its checking for 2 matches is because Regex returns a "Full Match" and "Group 1" 
                 // Both the exact same thing in this case.
-                
+
                 $regex = '/(\d{12})/m';
-                preg_match_all($regex, $ebay_url, $matches, PREG_SET_ORDER, 0);
+
+                // Gnadelwartz: IMHO itemid is always prefixed by  '/' and postfixed with  '/' or '?' or newline ('$')
+		// uncomment to activate
+                // $regex = '/\/(\d{12})[\/?]/m';
+                preg_match_all($regex, $ebay_url."/", $matches, PREG_SET_ORDER, 0);
+
                 if(count($matches[0]) == 2){
                     
                     // Logging Options
                     $this->Log(true, "GrabItemID(\"{$ebay_url}\");", "Success");
                     
+                $regex = '/(\d{12})/m';
                     // Proceed  
-                    return $matches[0][0];
+                    return $matches[0][1];
 
                 } else if (count($matches[0]) > 2){
 

--- a/ebay_api.php
+++ b/ebay_api.php
@@ -74,7 +74,7 @@
             }
         }
 
-        function GetSingleItem($item_id, $site_id, $html_description){
+        function GetSingleItemData($item_id, $site_id, $html_description){
             if($html_description === true){
                 // You can't grab both at the same time. So you have to ask for either or. Default is without the HTML Mark-up.
                 $request_url = "{$this->ebay_api_url}/shopping?" 
@@ -95,10 +95,13 @@
                 . "&ItemID={$item_id}"
                 . "&IncludeSelector=Details,Description,TextDescription,ItemSpecifics,Variations,Compatibility";
             }
-
             $request = file_get_contents($request_url);
             $data = simplexml_load_string($request);
-            
+            return $data;
+        }
+
+        function GetSingleItem($item_id, $site_id, $html_description){
+            $data = $this->GetSingleItemData($item_id, $site_id, $html_description);
             if($data->Ack == "Success"){
 
                 if($this->write_call_logs){

--- a/ebay_api.php
+++ b/ebay_api.php
@@ -92,7 +92,6 @@
                 . "&version={$this->ebay_api_version}"
                 . "&ItemID={$item_id}"
                 . $selector;
-print($request_url.PHP_EOL);
             $request = file_get_contents($request_url);
             $data = simplexml_load_string($request);
             return $data;

--- a/ebay_api.php
+++ b/ebay_api.php
@@ -74,7 +74,12 @@
             }
         }
 
-        function GetSingleItemData($item_id, $site_id, $html_description){
+        function GetSingleItemData($item_id, $site_id, $html_description,
+                     $selector="&IncludeSelector=Details,Description,TextDescription,ItemSpecifics,Variations,Compatibility"){
+            // add &selector= if not given
+            if (strlen($selector) >1 && $selector[0] != '&') {
+                $selector="&selector=".$selector;
+            } 
             if($html_description === true){
                 // You can't grab both at the same time. So you have to ask for either or. Default is without the HTML Mark-up.
                 $request_url = "{$this->ebay_api_url}/shopping?" 
@@ -84,7 +89,7 @@
                 . "&siteid={$site_id}"
                 . "&version={$this->ebay_api_version}"
                 . "&ItemID={$item_id}"
-                . "&IncludeSelector=Details,Description,ItemSpecifics,Variations,Compatibility";
+                . $selector;
             } else {
                 $request_url = "{$this->ebay_api_url}/shopping?" 
                 . "callname=GetSingleItem"
@@ -93,15 +98,15 @@
                 . "&siteid={$site_id}"
                 . "&version={$this->ebay_api_version}"
                 . "&ItemID={$item_id}"
-                . "&IncludeSelector=Details,Description,TextDescription,ItemSpecifics,Variations,Compatibility";
+                . $selector;
             }
             $request = file_get_contents($request_url);
             $data = simplexml_load_string($request);
             return $data;
         }
 
-        function GetSingleItem($item_id, $site_id, $html_description){
-            $data = $this->GetSingleItemData($item_id, $site_id, $html_description);
+        function GetSingleItem($item_id, $site_id, $html_description=false, $selector="") {
+            $data = $this->GetSingleItemData($item_id, $site_id, $html_description, $selector);
             if($data->Ack == "Success"){
 
                 if($this->write_call_logs){


### PR DESCRIPTION
I was looking for a simple solution to request item data from ebay. Most solutions are complex to use or outdated. So I was happy to find your API-Wrapper providing exactly what I've looked for.

As wanted to access [all Data](https://developer.ebay.com/devzone/shopping/docs/callref/getsingleitem.html) but to be more flexible I  added the function 'GetSingleItemData()'.
In Addtion I made the API selector parameter an optional argument. ''GetSingleItem()' works as before.

I'm now able to request specific data for Items and do better error processing: 

```php
    $ebay_api = new ebay_api();
    $data = $ebay_api->GetSingleItemData("1xxxxxxxxxx5", "77", false, ""); //only minimum selectors is faster

    if(isset($data->Ack) && $data->Ack == "Success") {
        print("Titel: ".$data->Item->Title.PHP_EOL);
    } else {
        if (isset($data->Errors->ErrorCode)) {
            print("{$data->Timestamp} Error {$data->Errors->ErrorCode}: {$data->Errors->LongMessage}".PHP_EOL);
        } else {
            print("Unknown Error: Dumpimg Data ...".PHP_EOL.$data.PHP_EOL);
        }
    }

```

May be you find it usefull ...